### PR TITLE
feat: the ability to receive photo/document messages and download files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "anyhow",
  "argh",
  "async-trait",
+ "bytes",
  "chrono",
  "derive_more",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ async-trait = "0.1.68"
 chrono = "0.4.24"
 regex = "1.8.2"
 mobot-derive = { version = "0.1.0", path = "mobot-derive" }
+bytes = "1.4.0"

--- a/src/bin/get_file.rs
+++ b/src/bin/get_file.rs
@@ -1,0 +1,36 @@
+/// This is a simple bot that download all sent files in directory beside bot executable
+use mobot::{
+    api::{DownloadRequest, GetFileRequest},
+    *,
+};
+use std::env;
+
+async fn get_user_file(e: Event, _: State<()>) -> Result<Action, anyhow::Error> {
+    let telegram_file = e
+        .api
+        .get_file(&GetFileRequest::new(
+            e.update.document().unwrap().file_id.clone(),
+        ))
+        .await?;
+    let mut file = std::fs::File::create(format!("{}", telegram_file.file_id))?;
+    let mut content = std::io::Cursor::new(
+        e.api
+            .download_file(&DownloadRequest::new(telegram_file.file_path.unwrap()))
+            .await
+            .unwrap(),
+    );
+    std::io::copy(&mut content, &mut file)?;
+    Ok(Action::ReplyText("File saved".into()))
+}
+
+#[tokio::main]
+async fn main() {
+    let client = Client::new(env::var("TELEGRAM_TOKEN").unwrap().into());
+    let mut router = Router::<()>::new(client);
+
+    router.add_route(Route::Message(Matcher::Document), get_user_file);
+    router.add_route(Route::Message(Matcher::Photo), |_, _| async move {
+        Ok(Action::ReplyText("Send a file, not a photo.".into()))
+    });
+    router.start().await;
+}

--- a/src/bin/get_photo.rs
+++ b/src/bin/get_photo.rs
@@ -1,0 +1,36 @@
+/// This is a simple bot that download all sent photos in directory beside bot executable
+use mobot::{
+    api::{DownloadRequest, GetFileRequest},
+    *,
+};
+use std::env;
+
+async fn get_user_file(e: Event, _: State<()>) -> Result<Action, anyhow::Error> {
+    let telegram_file = e
+        .api
+        .get_file(&GetFileRequest::new(
+            e.update.photo().unwrap().last().unwrap().clone().file_id,
+        ))
+        .await?;
+    let mut file = std::fs::File::create(format!("{}", telegram_file.file_id))?;
+    let mut content = std::io::Cursor::new(
+        e.api
+            .download_file(&DownloadRequest::new(telegram_file.file_path.unwrap()))
+            .await
+            .unwrap(),
+    );
+    std::io::copy(&mut content, &mut file)?;
+    Ok(Action::ReplyText("Photo saved".into()))
+}
+
+#[tokio::main]
+async fn main() {
+    let client = Client::new(env::var("TELEGRAM_TOKEN").unwrap().into());
+    let mut router = Router::<()>::new(client);
+
+    router.add_route(Route::Message(Matcher::Photo), get_user_file);
+    router.add_route(Route::Message(Matcher::Document), |_, _| async move {
+        Ok(Action::ReplyText("Send a photo, not a file.".into()))
+    });
+    router.start().await;
+}

--- a/src/bin/get_photo.rs
+++ b/src/bin/get_photo.rs
@@ -5,7 +5,7 @@ use mobot::{
 };
 use std::env;
 
-async fn get_user_file(e: Event, _: State<()>) -> Result<Action, anyhow::Error> {
+async fn get_user_photo(e: Event, _: State<()>) -> Result<Action, anyhow::Error> {
     let telegram_file = e
         .api
         .get_file(&GetFileRequest::new(
@@ -28,7 +28,7 @@ async fn main() {
     let client = Client::new(env::var("TELEGRAM_TOKEN").unwrap().into());
     let mut router = Router::<()>::new(client);
 
-    router.add_route(Route::Message(Matcher::Photo), get_user_file);
+    router.add_route(Route::Message(Matcher::Photo), get_user_photo);
     router.add_route(Route::Message(Matcher::Document), |_, _| async move {
         Ok(Action::ReplyText("Send a photo, not a file.".into()))
     });

--- a/src/lib/api/document.rs
+++ b/src/lib/api/document.rs
@@ -1,0 +1,22 @@
+use mobot_derive::BotRequest;
+use serde::{Deserialize, Serialize};
+
+use super::{PhotoSize};
+
+#[derive(Debug, Clone, Deserialize, Serialize, BotRequest)]
+pub struct Document {
+    /// Unique identifier for this file
+    pub file_id: String,
+
+    // Document thumbnail as defined by sender
+    pub thumbnail: Option<PhotoSize>,
+
+    // Original filename as defined by sender
+    pub file_name: Option<String>,
+
+    // MIME type of the file as defined by sender
+    pub mime_type: Option<String>,
+
+    /// File size
+    pub file_size: Option<i64>,
+}

--- a/src/lib/api/document.rs
+++ b/src/lib/api/document.rs
@@ -1,20 +1,19 @@
-use mobot_derive::BotRequest;
 use serde::{Deserialize, Serialize};
 
-use super::{PhotoSize};
+use super::PhotoSize;
 
-#[derive(Debug, Clone, Deserialize, Serialize, BotRequest)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Document {
-    /// Unique identifier for this file
+    /// Identifier for this file, which can be used to download or reuse the file
     pub file_id: String,
 
-    // Document thumbnail as defined by sender
+    /// Document thumbnail as defined by sender
     pub thumbnail: Option<PhotoSize>,
 
-    // Original filename as defined by sender
+    /// Original filename as defined by sender
     pub file_name: Option<String>,
 
-    // MIME type of the file as defined by sender
+    /// MIME type of the file as defined by sender
     pub mime_type: Option<String>,
 
     /// File size

--- a/src/lib/api/file.rs
+++ b/src/lib/api/file.rs
@@ -1,0 +1,35 @@
+use mobot_derive::BotRequest;
+use serde::{Deserialize, Serialize};
+
+use super::{API};
+
+#[derive(Debug, Clone, Deserialize, Serialize, BotRequest)]
+pub struct File {
+    /// Unique identifier for this file
+    pub file_id: String,
+
+    /// File size
+    pub file_size: Option<i64>,
+
+    pub file_path: Option<String>
+}
+
+#[derive(Debug, Serialize, Clone, BotRequest)]
+pub struct GetFileRequest {
+    /// Unique identifier for target file
+    pub file_id: i64,
+}
+
+impl GetFileRequest {
+    pub fn new(file_id: i64) -> Self {
+        Self {
+            file_id
+        }
+    }
+}
+
+impl API {
+    pub async fn get_file(&self, req: &GetFileRequest) -> anyhow::Result<File> {
+        self.client.post("getFile", req).await
+    }
+}

--- a/src/lib/api/file.rs
+++ b/src/lib/api/file.rs
@@ -1,3 +1,4 @@
+use bytes;
 use mobot_derive::BotRequest;
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +12,7 @@ pub struct File {
     /// File size
     pub file_size: Option<i64>,
 
-    /// File path. Use mobot::api::get_file to get the file
+    /// File path. You can use it with api.download_file to download file
     pub file_path: Option<String>,
 }
 
@@ -27,8 +28,23 @@ impl GetFileRequest {
     }
 }
 
+#[derive(Debug, Serialize, Clone, BotRequest)]
+pub struct DownloadRequest {
+    /// File path. You can use it with api.download_file to download file
+    pub file_path: String,
+}
+
+impl DownloadRequest {
+    pub fn new(file_path: String) -> Self {
+        Self { file_path }
+    }
+}
+
 impl API {
     pub async fn get_file(&self, req: &GetFileRequest) -> anyhow::Result<File> {
         self.client.post("getFile", req).await
+    }
+    pub async fn download_file(&self, req: &DownloadRequest) -> anyhow::Result<bytes::Bytes> {
+        self.client.download_file(&req.file_path).await
     }
 }

--- a/src/lib/api/file.rs
+++ b/src/lib/api/file.rs
@@ -1,17 +1,18 @@
 use mobot_derive::BotRequest;
 use serde::{Deserialize, Serialize};
 
-use super::{API};
+use super::API;
 
-#[derive(Debug, Clone, Deserialize, Serialize, BotRequest)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct File {
-    /// Unique identifier for this file
+    /// Identifier for this file, which can be used to download or reuse the file
     pub file_id: String,
 
     /// File size
     pub file_size: Option<i64>,
 
-    pub file_path: Option<String>
+    /// File path. Use mobot::api::get_file to get the file
+    pub file_path: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone, BotRequest)]
@@ -22,9 +23,7 @@ pub struct GetFileRequest {
 
 impl GetFileRequest {
     pub fn new(file_id: String) -> Self {
-        Self {
-            file_id
-        }
+        Self { file_id }
     }
 }
 

--- a/src/lib/api/file.rs
+++ b/src/lib/api/file.rs
@@ -17,11 +17,11 @@ pub struct File {
 #[derive(Debug, Serialize, Clone, BotRequest)]
 pub struct GetFileRequest {
     /// Unique identifier for target file
-    pub file_id: i64,
+    pub file_id: String,
 }
 
 impl GetFileRequest {
-    pub fn new(file_id: i64) -> Self {
+    pub fn new(file_id: String) -> Self {
         Self {
             file_id
         }

--- a/src/lib/api/file.rs
+++ b/src/lib/api/file.rs
@@ -44,6 +44,7 @@ impl API {
     pub async fn get_file(&self, req: &GetFileRequest) -> anyhow::Result<File> {
         self.client.post("getFile", req).await
     }
+    /// Download file by its file_path. File must be no larger than 20 mb
     pub async fn download_file(&self, req: &DownloadRequest) -> anyhow::Result<bytes::Bytes> {
         self.client.download_file(&req.file_path).await
     }

--- a/src/lib/api/message.rs
+++ b/src/lib/api/message.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 use mobot_derive::BotRequest;
 use serde::{Deserialize, Serialize};
 
-use super::{chat::Chat, PhotoSize, sticker::Sticker, user::User, ReplyMarkup, API, Document};
+use super::{chat::Chat, sticker::Sticker, user::User, Document, PhotoSize, ReplyMarkup, API};
 
 /// `Message` represents a message sent in a chat. It can be a text message, a sticker, a photo, etc.
 /// <https://core.telegram.org/bots/api#message>
@@ -22,14 +22,14 @@ pub struct Message {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
 
-    // Message is a photo, available sizes of the photo
+    /// Message is a photo, available sizes of the photo
     #[serde(skip_serializing_if = "Option::is_none")]
     pub photo: Option<Vec<PhotoSize>>,
 
-    // Message is a general file, information about the file
+    /// Message is a general file, information about the file
     #[serde(skip_serializing_if = "Option::is_none")]
     pub document: Option<Document>,
-    
+
     /// Conversation the message belongs to
     /// - For sent messages, the first available identifier of the chat
     /// - For messages forwarded to the chat, the identifier of the original chat

--- a/src/lib/api/message.rs
+++ b/src/lib/api/message.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 use mobot_derive::BotRequest;
 use serde::{Deserialize, Serialize};
 
-use super::{chat::Chat, sticker::Sticker, user::User, ReplyMarkup, API};
+use super::{chat::Chat, PhotoSize, sticker::Sticker, user::User, ReplyMarkup, API, Document};
 
 /// `Message` represents a message sent in a chat. It can be a text message, a sticker, a photo, etc.
 /// <https://core.telegram.org/bots/api#message>
@@ -22,6 +22,14 @@ pub struct Message {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
 
+    // Message is a photo, available sizes of the photo
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub photo: Option<Vec<PhotoSize>>,
+
+    // Message is a general file, information about the file
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub document: Option<Document>,
+    
     /// Conversation the message belongs to
     /// - For sent messages, the first available identifier of the chat
     /// - For messages forwarded to the chat, the identifier of the original chat

--- a/src/lib/api/mod.rs
+++ b/src/lib/api/mod.rs
@@ -8,6 +8,9 @@ pub mod reply_markup;
 pub mod sticker;
 pub mod update;
 pub mod user;
+pub mod photo_size;
+pub mod file;
+pub mod document;
 
 pub use api::*;
 pub use chat::*;
@@ -18,3 +21,6 @@ pub use reply_markup::*;
 pub use sticker::*;
 pub use update::*;
 pub use user::*;
+pub use photo_size::*;
+pub use file::*;
+pub use document::*;

--- a/src/lib/api/photo_size.rs
+++ b/src/lib/api/photo_size.rs
@@ -1,15 +1,14 @@
-use mobot_derive::BotRequest;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize, BotRequest)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PhotoSize {
-    /// Unique identifier for this file
+    /// Identifier for this file, which can be used to download or reuse the file
     pub file_id: String,
 
-    /// Sticker width
+    /// Photo width
     pub width: i64,
 
-    /// Sticker height
+    /// Photo height
     pub height: i64,
 
     /// File size

--- a/src/lib/api/photo_size.rs
+++ b/src/lib/api/photo_size.rs
@@ -1,0 +1,17 @@
+use mobot_derive::BotRequest;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize, BotRequest)]
+pub struct PhotoSize {
+    /// Unique identifier for this file
+    pub file_id: String,
+
+    /// Sticker width
+    pub width: i64,
+
+    /// Sticker height
+    pub height: i64,
+
+    /// File size
+    pub file_size: Option<i64>,
+}

--- a/src/lib/router.rs
+++ b/src/lib/router.rs
@@ -45,8 +45,10 @@ pub enum Matcher {
     /// Handle bot commands (messages that start with "/")
     BotCommand(String),
 
+    /// Match messages that represent a photo
     Photo,
 
+    /// Match messages that represent a general file
     Document
 }
 

--- a/src/lib/router.rs
+++ b/src/lib/router.rs
@@ -47,7 +47,7 @@ pub enum Matcher {
 
     Photo,
 
-    File
+    Document
 }
 
 impl Matcher {
@@ -58,7 +58,7 @@ impl Matcher {
             Self::Prefix(m) => s.starts_with(m),
             Self::Regex(m) => regex::Regex::new(m).unwrap().is_match(s),
             Self::BotCommand(m) => s.starts_with(&format!("/{}", m)),
-            Self::File | Self::Photo => false,
+            Self::Document | Self::Photo => false,
         }
     }
 }
@@ -170,7 +170,7 @@ impl Route {
                         .as_ref()
                         .and_then(|m| m.photo.as_ref()).is_some() 
                     },
-                    Matcher::File => {
+                    Matcher::Document => {
                         update
                         .message
                         .as_ref()

--- a/src/lib/router.rs
+++ b/src/lib/router.rs
@@ -44,6 +44,10 @@ pub enum Matcher {
 
     /// Handle bot commands (messages that start with "/")
     BotCommand(String),
+
+    Photo,
+
+    File
 }
 
 impl Matcher {
@@ -54,6 +58,7 @@ impl Matcher {
             Self::Prefix(m) => s.starts_with(m),
             Self::Regex(m) => regex::Regex::new(m).unwrap().is_match(s),
             Self::BotCommand(m) => s.starts_with(&format!("/{}", m)),
+            Self::File | Self::Photo => false,
         }
     }
 }
@@ -157,11 +162,29 @@ impl Route {
 
     pub fn match_update(&self, update: &api::Update) -> bool {
         match self {
-            Self::Message(m) => update
-                .message
-                .as_ref()
-                .and_then(|m| m.text.as_ref())
-                .map_or(false, |t| m.match_str(t)),
+            Self::Message(m) => {
+                match m {
+                    Matcher::Photo => {
+                        update
+                        .message
+                        .as_ref()
+                        .and_then(|m| m.photo.as_ref()).is_some() 
+                    },
+                    Matcher::File => {
+                        update
+                        .message
+                        .as_ref()
+                        .and_then(|m| m.document.as_ref()).is_some()      
+                    }
+                    _ => {
+                        update
+                        .message
+                        .as_ref()
+                        .and_then(|m| m.text.as_ref())
+                        .map_or(false, |t| m.match_str(t))
+                    }
+                }
+            },
             Self::EditedMessage(m) => update
                 .edited_message
                 .as_ref()

--- a/src/lib/update.rs
+++ b/src/lib/update.rs
@@ -1,4 +1,4 @@
-use crate::api;
+use crate::api::{self, PhotoSize, Document};
 use anyhow::anyhow;
 
 /// `Update` represents a new update from Telegram
@@ -178,6 +178,22 @@ impl Update {
                 .as_ref()
                 .ok_or(anyhow!("message has no text"))
                 .map(|s| s.as_str())
+        })
+    }
+
+    pub fn photo(&self) -> anyhow::Result<&Vec<PhotoSize>> {
+        self.message().and_then(|msg| {
+            msg.photo
+                .as_ref()
+                .ok_or(anyhow!("message has no photo"))
+        })
+    }
+
+    pub fn document(&self) -> anyhow::Result<&Document> {
+        self.message().and_then(|msg| {
+            msg.document
+                .as_ref()
+                .ok_or(anyhow!("message has no document"))
         })
     }
 


### PR DESCRIPTION
#### Added
* [`PhotoSize`](https://core.telegram.org/bots/api#photosize), [`File`](https://core.telegram.org/bots/api#file) and [`Document`](https://core.telegram.org/bots/api#document) types according to telegram-api
* [`get_file`](https://core.telegram.org/bots/api#getfile) function to get [`File`](https://core.telegram.org/bots/api#file) object and `download_file` to download file by `file_path` from `File`
* `photo` and `document` fields for `message`
* `photo` and `document` methods for `update` similar to `text`
* `Matcher` for `Photo` and `Document` messages changed `match_update` how it handles `Message` to catch photo/document messages, changed `Matcher::match_str` to return `false` on `Photo` and `Document`
* added examples - simple bots. One downloads sent files, the other downloads sent photos

#### Notes:
I was not sure, how to handle downloading, because we need to use `https://api.telegram.org/file/bot<token>/<file_path>`  and not a `base_url`, and also there is no json-body in request - so I made a `download_file` method for `Client`.